### PR TITLE
Fix preprocessor output

### DIFF
--- a/lib/cast/preprocessor.rb
+++ b/lib/cast/preprocessor.rb
@@ -31,7 +31,7 @@ module C
         filename = file.path
         file.puts text
       end
-      output = `#{full_command(filename)} 2>&1`
+      output = `#{full_command(filename)}`
       if $? == 0
         return output
       else

--- a/test/preprocessor_test.rb
+++ b/test/preprocessor_test.rb
@@ -84,4 +84,8 @@ EOS
     assert_match(/int two = 2;/, output)
     assert_match(/int three = 3;/, output)
   end
+  def test_proprocess_warning
+    output = cpp.preprocess("#warning warning me!")
+    assert output.gsub(/^#.*\n/,"").gsub(/[ \t\n]/,"").length == 0
+  end
 end


### PR DESCRIPTION
Error message is mixed into the output of the preprocessor.
Message of "#warning" should be output to stderr.

```shell
[1] pry(main)> require 'cast'
=> true
[2] pry(main)> cpp = C::Preprocessor.new
=> #<C::Preprocessor:0x007fd42a5c16f0 @include_path=[], @macros={}>
[3] pry(main)> C::Preprocessor.command = 'clang -P -E'
=> "clang -P -E"
[4] pry(main)> cpp.preprocess("#warning user warning")
=> "/Users/user/src/cast/cast-preprocessor-input.20140507-11854-hpifho.c:1:2: warning: user warning [-W#warnings]\n#warning user warning\n ^\n\n1 warning generated.\n"
```
`cpp.preprocess("#warning user warning")` should be empty string.