### PR TITLE
Fix a few Minitest warnings about assert_nil

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 /ext/Makefile
 /ext/*.bundle
 /ext/*.o
+/ext/*.so
 /ext/yylex.c
+/lib/cast/cast.so
 /lib/cast/c.tab.rb
 /lib/cast/cast.bundle

--- a/test/c_nodes_test.rb
+++ b/test/c_nodes_test.rb
@@ -194,7 +194,7 @@ EOS
 
     c.wide = false
     assert(!c.wide?)
-    assert_equal(nil, c.prefix)
+    assert_nil(c.prefix)
   end
   def test_string_literal_wide
     s = C::StringLiteral.new('abc', 'L')
@@ -219,6 +219,6 @@ EOS
 
     s.wide = false
     assert(!s.wide?)
-    assert_equal(nil, s.prefix)
+    assert_nil(s.prefix)
   end
 end

--- a/test/node_list_test.rb
+++ b/test/node_list_test.rb
@@ -1298,7 +1298,7 @@ module NodeListArrayQueryTests
     assert_equal(0, list.index(a))
     assert_equal(1, list.index(l1))
     assert_equal(1, list.index(_List[C::Int.new(2)]))
-    assert_equal(nil, list.index([b]))
+    assert_nil(list.index([b]))
     assert_nil(list.index([a]))
     assert_nil(list.index(C::Int.new))
     assert_nil(list.index(nil))


### PR DESCRIPTION
A warning example:
```
DEPRECATED: Use assert_nil if expecting nil from /home/ch1c0t/sources/aliens/c_parsers/cast/test/node_list_test.rb:1301. This will fail in Minitest 6.
```