### PR TITLE
Delete #assert_invariants

### DIFF
--- a/lib/cast/node.rb
+++ b/lib/cast/node.rb
@@ -10,20 +10,6 @@ module C
   #
   class Node
     #
-    # Called by the test suite to ensure all invariants are true.
-    #
-    def assert_invariants(testcase)
-      fields.each do |field|
-        if val = send(field.reader)
-          assert_same(self, node.parent, "field.reader is #{field.reader}")
-          if field.child?
-            assert_same(field, val.instance_variable_get(:@parent_field), "field.reader is #{field.reader}")
-          end
-        end
-      end
-    end
-
-    #
     # Like self.new, but the first argument is taken as the position
     # of the Node.
     #

--- a/lib/cast/node_list.rb
+++ b/lib/cast/node_list.rb
@@ -148,14 +148,6 @@ module C
   end
 
   class NodeArray
-    def assert_invariants(testcase)
-      super
-      testcase.assert_same(::Array, @array)
-      @array.each_with_index do |node, i|
-        assert_same(i, node.instance_variable_get(:@parent_index))
-      end
-    end
-
     def initialize
       super
       @array = []
@@ -177,31 +169,6 @@ module C
   end
 
   class NodeChain
-    def assert_invariants(testcase)
-      super
-      assert_same(@length.zero?, @first.nil?)
-      assert_same(@length.zero?, @last.nil?)
-      unless @length.zero?
-        assert_same(@first, self[0])
-        assert_same(@last, self[@length-1])
-        (0...@length.times).each do |i|
-          nodeprev = self[i].instance_variable_get(:@prev)
-          nodenext = self[i].instance_variable_get(:@next)
-          if i == 0
-            assert_nil(nodeprev)
-          else
-            assert_same(self[i-1], nodeprev)
-          end
-
-          if i == @length-1
-            assert_nil(nodenext)
-          else
-            assert_same(self[i+1], nodenext)
-          end
-        end
-      end
-    end
-
     def initialize
       super
       @first = nil

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -189,10 +189,4 @@ module Minitest::Assertions
     refute_same exp, out
     assert_equal exp, out
   end
-  #
-  # Assert the invariants of `node'.
-  #
-  def assert_invariants(node)
-    node.assert_invariants(self)
-  end
 end


### PR DESCRIPTION
The comment in `lib/cast/node.rb` states that #assert_invariants

>Called by the test suite to ensure all invariants are true.

but that does not seem to be the case.

`git grep -n 'assert_invariants'`:
```
lib/cast/node.rb:15:    def assert_invariants(testcase)
lib/cast/node_list.rb:151:    def assert_invariants(testcase)
lib/cast/node_list.rb:180:    def assert_invariants(testcase)
test/test_helper.rb:195:  def assert_invariants(node)
test/test_helper.rb:196:    node.assert_invariants(self)
```
After deleting `assert_invariants` from `lib/**/*.rb`, all the tests still pass.
This can be staled code(in which case it should be deleted), or some tests using it should be created.