### PR TITLE
Support GCC-specific __extension__ keyword

### DIFF
--- a/ext/cast.h
+++ b/ext/cast.h
@@ -84,6 +84,7 @@ extern VALUE cast_sym_RESTRICT;
 extern VALUE cast_sym_BOOL;
 extern VALUE cast_sym_COMPLEX;
 extern VALUE cast_sym_IMAGINARY;
+extern VALUE cast_sym_EXTENSION; /* GCC extension: __extension__ */
 
 extern VALUE cast_sym_FCON;
 extern VALUE cast_sym_ICON;

--- a/ext/parser.c
+++ b/ext/parser.c
@@ -45,6 +45,7 @@ VALUE cast_sym_RESTRICT;
 VALUE cast_sym_BOOL;
 VALUE cast_sym_COMPLEX;
 VALUE cast_sym_IMAGINARY;
+VALUE cast_sym_EXTENSION; /* GCC extension: __extension__ */
 
 VALUE cast_sym_FCON;
 VALUE cast_sym_ICON;
@@ -229,6 +230,7 @@ void cast_init_parser(void) {
   cast_sym_BOOL        = ID2SYM(rb_intern("BOOL"));
   cast_sym_COMPLEX     = ID2SYM(rb_intern("COMPLEX"));
   cast_sym_IMAGINARY   = ID2SYM(rb_intern("IMAGINARY"));
+  cast_sym_EXTENSION   = ID2SYM(rb_intern("EXTENSION")); /* GCC extension: __extension__ */
 
   cast_sym_FCON        = ID2SYM(rb_intern("FCON"));
   cast_sym_ICON        = ID2SYM(rb_intern("ICON"));

--- a/ext/yylex.re
+++ b/ext/yylex.re
@@ -132,9 +132,12 @@ void yylex(VALUE self, cast_Parser *p) {
     "while"      { RET(cast_sym_WHILE); }
     "inline"     { RET(cast_sym_INLINE); }
     "restrict"   { RET(cast_sym_RESTRICT); }
+
     "_Bool"      { RET(cast_sym_BOOL); }
     "_Complex"   { RET(cast_sym_COMPLEX); }
     "_Imaginary" { RET(cast_sym_IMAGINARY); }
+
+    "__extension__" { RET(cast_sym_EXTENSION); } /* GCC extension */
 
     L (L|D)* {
         value = rb_str_new(p->tok, cursor - p->tok);

--- a/lib/cast/c.y
+++ b/lib/cast/c.y
@@ -12,8 +12,11 @@ translation_unit
 
 # Returns Declaration|FunctionDef
 external_declaration
-  : function_definition {result = val[0]}
-  | declaration         {result = val[0]}
+  : function_definition            {result = val[0]}
+  | declaration                    {result = val[0]}
+  # GCC EXTENSION: __extension__ can go before any external declaration
+  # this has no effect aside from suppressing certain warnings
+  | EXTENSION external_declaration {result = val[1]}
 
 # Returns FunctionDef
 function_definition
@@ -172,7 +175,9 @@ struct_declaration_list
 
 # Returns Declaration
 struct_declaration
-  : specifier_qualifier_list struct_declarator_list SEMICOLON {result = make_declaration(val[0][0], val[0][1], val[1])}
+  : specifier_qualifier_list struct_declarator_list SEMICOLON           {result = make_declaration(val[0][0], val[0][1], val[1])}
+  # GCC EXTENSION: __extension__ can go before any struct_declaration
+  | EXTENSION specifier_qualifier_list struct_declarator_list SEMICOLON {result = make_declaration(val[1][0], val[1][1], val[2])}
 
 # Returns {Pos, [Symbol]}
 specifier_qualifier_list
@@ -381,6 +386,8 @@ unary_expression
   | unary_operator cast_expression {result = val[0][0].new_at(val[0][1], val[1])}
   | SIZEOF unary_expression        {result = Sizeof.new_at(val[0].pos, val[1])}
   | SIZEOF LPAREN type_name RPAREN {result = Sizeof.new_at(val[0].pos, val[2])}
+  # GCC extension: __extension__
+  | EXTENSION cast_expression      {result = val[1]}
 
 # Returns [Class, Pos]
 unary_operator

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -118,6 +118,64 @@ TranslationUnit
 EOS
   end
 
+  def test_external_declaration_with_extension_kw
+    check <<EOS
+__extension__ typedef int blah;
+----
+TranslationUnit
+     entities:
+         - Declaration
+             storage: typedef
+             type: Int
+             declarators:
+                 - Declarator
+                     name: "blah"
+EOS
+  end
+
+def test_struct_member_declaration_with_extension_kw
+  check <<EOS
+struct { __extension__ int i; int j; } blah;
+----
+TranslationUnit
+     entities:
+         - Declaration
+             type: Struct
+                 members:
+                     - Declaration
+                         type: Int
+                         declarators:
+                             - Declarator
+                                 name: "i"
+                     - Declaration
+                         type: Int
+                         declarators:
+                             - Declarator
+                                 name: "j"
+             declarators:
+                 - Declarator
+                     name: "blah"
+EOS
+end
+
+def test_unary_extension_kw
+  check <<EOS
+void f() { __extension__ 0; }
+----
+TranslationUnit
+    entities:
+        - FunctionDef
+            type: Function
+                type: Void
+            name: "f"
+            def: Block
+                stmts:
+                    - ExpressionStatement
+                        expr: IntLiteral
+                            val: 0
+EOS
+end
+
   def test_function_def
     check <<EOS
 int main(int, char **) {}


### PR DESCRIPTION
Some projects which are specifically written to be compiled by GCC use GCC-specific
extensions to the C language, such as the `__extension__` keyword. This is an interesting extension; it has no effect on the meaning of the code, but merely suppresses compiler warnings. Therefore, the AST does not need to change in any way.

The modifications to the grammar were made after carefully examining the source for the GCC parser to see where `__extension__` can be used in GNU C.