### PR TITLE
Added support for anonymous structs and unions.

### DIFF
--- a/lib/cast/c.y
+++ b/lib/cast/c.y
@@ -173,6 +173,7 @@ struct_declaration_list
 # Returns Declaration
 struct_declaration
   : specifier_qualifier_list struct_declarator_list SEMICOLON {result = make_declaration(val[0][0], val[0][1], val[1])}
+  | specifier_qualifier_list                        SEMICOLON {result = make_declaration(val[0][0], val[0][1], NodeArray[])}
 
 # Returns {Pos, [Symbol]}
 specifier_qualifier_list


### PR DESCRIPTION
This commit was written without access to the C11 grammar, so I don't know how the support is added in C11. Unfortunately the feature wasn't in C11 provisional.

Edit: On the C17 provisional specification the struct-declarator-list becomes optional, so this patch should be fine:
![image](https://user-images.githubusercontent.com/1815142/87494877-b2869a00-c615-11ea-9a2e-0512bca8db4e.png)
