### PR TITLE
Preprocessor fixes

### DIFF
--- a/lib/cast/preprocessor.rb
+++ b/lib/cast/preprocessor.rb
@@ -29,11 +29,13 @@ module C
     end
     def preprocess(text)
       filename = nil
-      Tempfile.open(['cast-preprocessor-input.', '.c'], File.expand_path(pwd || '.')) do |file|
+      output = nil
+      Tempfile.open(['cast-preprocessor-input.', '.c']) do |file|
         filename = file.path
         file.puts text
+	file.flush
+        output = `#{full_command(filename)} #{'2> /dev/null' if @quiet}`
       end
-      output = `#{full_command(filename)} #{'2> /dev/null' if @quiet}`
       if $? == 0
         return output
       else


### PR DESCRIPTION
1. Don't delete the preprocessor file before running cpp
2. Use the system temp dir, not the location (Fixes #4 )

I kept getting `cpp` complaining that the file couldn't be found under heavy IO load, and then realized this fix was necessary as the tempfile was being deleted before gcc could read it

```txt
gcc: error: /home/byteit101/project/cast-preprocessor-input.20221001-1388787-1lxyy5.c: No such file or directory
gcc: fatal error: no input files
compilation terminated.
Traceback (most recent call last):
	1: from test.rb:6:in `<main>'
/home/byteit101/rvm/gems/ruby-2.6.2/gems/cast-0.3.1/lib/cast/preprocessor.rb:40:in `preprocess': C::Preprocessor::Error
```