### PR TITLE
Fix race condition with GC in preprocessor.

### DIFF
--- a/lib/cast/preprocessor.rb
+++ b/lib/cast/preprocessor.rb
@@ -28,12 +28,14 @@ module C
       @quiet = quiet
     end
     def preprocess(text)
-      filename = nil
+      # Tempfile will delete file after garbage collection, which can happen
+      # after the below block if the object is not saved.
+      f = nil
       Tempfile.open(['cast-preprocessor-input.', '.c'], File.expand_path(pwd || '.')) do |file|
-        filename = file.path
+        f = file
         file.puts text
       end
-      output = `#{full_command(filename)} #{'2> /dev/null' if @quiet}`
+      output = `#{full_command(f.path)} #{'2> /dev/null' if @quiet}`
       if $? == 0
         return output
       else


### PR DESCRIPTION
Hello,

This addresses the same issue as https://github.com/oggy/cast/pull/23, thought the fix is maybe a little less change. Realized after the fact.

This issue is triggered in GitHub actions with this kind of errors:
```
cc1: fatal error: /home/runner/work/THAPI/THAPI/hip/cast-preprocessor-input.20241114-16434-v1zmu7.c: No such file or directory
compilation terminated.
/var/lib/gems/3.2.0/gems/cast-0.3.1/lib/cast/preprocessor.rb:40:in `preprocess': C::Preprocessor::Error
	from extract_hip.rb:20:in `<main>'
```

Would it be possible to de a release of the gem including this fix?

Thanks